### PR TITLE
Remove display as table from css :syringe:

### DIFF
--- a/css/form_settings.css
+++ b/css/form_settings.css
@@ -2,7 +2,7 @@
 #gaddon-setting-row-company_map_fields .repeater th {
     padding-top: 0;
 }
-#gform_tab_group { display: table; width: 100%; }
+#gform_tab_group { width: 100%; }
 #tab_connectwise, #sidebar_section {
 	display: table-cell;
     height: 500px;


### PR DESCRIPTION
Change purpose in this pull request:
- Remove `display: table;` from CSS. (It make CSS in form setting page broken.)



Related card: https://trello.com/c/Mw9WFBHm/481-sp2-remove-unused-css-from-connectwise-plugin